### PR TITLE
Refactor data structures and controller actions issue #11

### DIFF
--- a/lib/learnathon/submission_manager/confirmation_code.ex
+++ b/lib/learnathon/submission_manager/confirmation_code.ex
@@ -10,18 +10,11 @@ defmodule Learnathon.SubmissionManager.ConfirmationCode do
     timestamps()
   end
 
-  def changeset(struct, params \\ %{}) do
-    struct
+  def changeset(confirmation_code, params \\ %{}) do
+    confirmation_code
     |> cast(params, [:email, :body, :person_id])
     |> put_assoc(:person, required: true)
     |> validate_required([:body])
-  end
-
-  def generate do
-    :crypto.
-      strong_rand_bytes(64)
-      |> Base.url_encode64
-      |> binary_part(0, 64)
   end
 
   def expired?(confirmation_code) do

--- a/lib/learnathon/submission_manager/person.ex
+++ b/lib/learnathon/submission_manager/person.ex
@@ -1,8 +1,5 @@
 defmodule Learnathon.SubmissionManager.Person do
   use Learnathon.Web, :model
-  alias Ecto.Changeset
-  alias Learnathon.{
-    SubmissionManager.Person, Repo, SubmissionManager.ConfirmationCode}
 
   schema "people" do
     field :name, :string
@@ -16,66 +13,11 @@ defmodule Learnathon.SubmissionManager.Person do
     field :contribution, :integer
     field :confirmed, :boolean
 
-    has_many :confirmation_codes, ConfirmationCode
-  end
-
-  def changeset(person, params \\ %{}) do
-    person
-    |> cast(params, permitted_attributes())
-    |> cast_assoc(:confirmation_codes, required: false)
-    |> validate_required([:name, :email])
-    |> unique_constraint(:email)
-    |> validate_format(:email, email_format_regex())
-  end
-
-  defp confirmation_code_presence(changeset) do
-    case Repo.get_by ConfirmationCode, email: changeset.email do
-      nil -> changeset
-      _ -> add_error(
-              changeset,
-              :confirmation_code,
-              """
-              You have already been sent a confirmation code.
-              Please check your spam filters or wait a few minutes
-              before trying again. Your existing Confirmation Code must expire
-              first before we can send you another one.
-              """
-            )
-    end
+    has_many :confirmation_codes, Learnathon.SubmissionManager.ConfirmationCode
   end
 
   def confirmed?(person) do
     person.confirmed == true
-  end
-
-  def new(attributes) do
-    changeset(%Person{}, attributes)
-  end
-
-  def last_created_confirmation_code(person) do
-    case length(person.confirmation_codes) do
-      0 -> create_confirmation_code(person)
-      _ -> List.last(person.confirmation_codes)
-    end
-    List.last(person.confirmation_codes)
-  end
-
-  defp create_confirmation_code(person) do
-      Ecto.
-      build_assoc(
-        person, 
-        :confirmation_codes,
-        body: ConfirmationCode.generate) |> Repo.insert!
-  end
-
-
-  defp permitted_attributes do
-    [:name, :email, :workshop_idea, :time_needed, :company, :contribution, 
-     :donation, :swag, :prizes, :confirmed]
-  end
-
-  defp email_format_regex do
-    ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/
   end
 
 end

--- a/lib/learnathon/submission_manager/submission_manager.ex
+++ b/lib/learnathon/submission_manager/submission_manager.ex
@@ -4,8 +4,12 @@ defmodule Learnathon.SubmissionManager do
   """
 
   import Ecto.{Query, Changeset}, warn: false
-  alias Learnathon.Repo
-  alias Learnathon.SubmissionManager.Person
+  alias Learnathon.{
+                     Repo,
+                     SubmissionManager,
+                     SubmissionManager.Person,
+                     SubmissionManager.ConfirmationCode
+                   }
 
   @doc """
   Returns a list of people.
@@ -21,7 +25,7 @@ defmodule Learnathon.SubmissionManager do
   end
 
   @doc """
-  Gets a person.
+  Gets a person by id but throws a NoResultsError.
 
   Raises `Ecto.NoResultsError` if the Person does not exist
 
@@ -34,8 +38,23 @@ defmodule Learnathon.SubmissionManager do
       ** (Ecto.NoResultsError)
 
   """
-
   def get_person!(id), do: Repo.get!(Person, id)
+
+  @doc """
+  Gets a person by id.
+
+  Returns `nil` if the Person does not exist
+
+  ## Examples
+
+      iex> get_person(1)
+      %Person{}
+
+      iex> get_person(2)
+      nil
+
+  """
+  def get_person(id), do: Repo.get(Person, id)
 
   @doc """
   Creates a person
@@ -67,7 +86,6 @@ defmodule Learnathon.SubmissionManager do
       {:error, %Ecto.Changeset{}}
 
   """
-
   def update_person(%Person{} = person, attrs) do
     person
     |> person_changeset(attrs)
@@ -80,22 +98,176 @@ defmodule Learnathon.SubmissionManager do
   ## Examples
   
       iex> change_person(person)
-      %Ecto.Changeset{confirmed: true}
+      %Ecto.Changeset{}
 
   """
-
   def change_person(%Person{} = person) do
     person_changeset(person, %{})
   end
 
-  defp person_changeset(%Person{} = person, attrs) do
+  @doc """
+  If person is found by email then return that Person.
+  If person is not found create person.
+
+  ## Examples
+
+      iex> get_or_create_person(changeset)
+      {:ok, %Person{name: "sam", email: "sam@gmail.com"}}
+
+  """
+  def get_or_create_person(submission) do
+    changeset = person_changeset(%Person{}, submission)
+    case Repo.get_by(Person, email: changeset.changes.email) do
+      nil -> create_person(changeset.changes)
+      person -> {:ok, person}
+    end
+  end
+
+  @doc """
+  Create a new confirmation code for a person.
+  If person is already confirmed return a tuple with an `:error` key.
+
+  ## Examples
+
+      iex> create_person_confirmation(person)
+      {:ok,
+        %Learnathon.SubmissionManager.
+          ConfirmationCode{
+            __meta__: #Ecto.Schema.Metadata<:loaded, "confirmation_codes">,
+            body: "e1qg709v-f1vENET0ifxdTOH34dROU6gfK6dvwxaOf2DMXpOZwjC6jc1-6",
+            email: nil, id: 44, inserted_at: ~N[2017-04-01 20:13:37.650429],
+            person: #Ecto.Association.NotLoaded<association :person is not loaded>,
+            person_id: 3, updated_at: ~N[2017-04-01 20:13:37.661758]}}
+
+      iex> create_person_confirmation(confirmed_person)
+      {:error, "You have already been confirmed."}
+  """
+
+  def create_person_confirmation(person) do
+    if person.confirmed == true do
+      {:error, "You have already been confirmed."}
+    else
+      Repo.transaction fn ->
+        Ecto.
+        build_assoc(person, 
+          :confirmation_codes, 
+          body: generate_hash())
+        |> Repo.insert!
+      end
+    end
+  end
+
+  @doc """
+  Generate a random string of 64 bytes.
+
+  ## Example
+
+    iex> generate_hash()
+    "bf55XEwhP3YD3tMmYVzSfIsBuIVttjWXDKccMSOFCN1NdOuOFv48Nbkwn8oOKqQA"
+
+  """
+
+  def generate_hash do
+    :crypto.
+      strong_rand_bytes(64)
+      |> Base.url_encode64
+      |> binary_part(0, 64)
+  end
+
+  @doc """
+  Get confirmation code by 64 byte string.
+  This is the same string that is the ConfirmationCode's :body
+
+  ## Example
+  
+      iex> get_confirmation_code(generated_hash)
+      {:ok, %Learnathon.SubmissionManager.
+        ConfirmationCode{__meta__: #Ecto.Schema.Metadata<:loaded, "confirmation_codes">,
+      body: "-VloupjQLGQu_45NVJmYT91NjSGtV836zZTQEseZE7X20iK1hmHDOIncCqRyTQ7A",
+      email: nil, id: 1, inserted_at: ~N[2017-03-29 16:56:12.603846],
+      person: #Ecto.Association.NotLoaded<association :person is not loaded>,
+      person_id: 1, updated_at: ~N[2017-03-29 16:56:12.616893]}}
+  """
+
+  def get_confirmation_code(cc) do
+    case Repo.get_by(ConfirmationCode, body: cc) do
+      nil -> {:error, "Could not find the confirmation code."}
+      confirmation_code -> {:ok, confirmation_code}
+    end
+  end
+
+  @doc """
+  Delete all confirmation codes associated with a person.
+  Return person without any confirmation codes
+
+  ## Example
+
+      iex> delete_all_confirmation_codes_for_person(person)
+      {:ok, person}
+
+  """
+  def delete_all_confirmation_codes_for_person(person) do
+    codes = person.confirmation_codes
+    delete_all_confirmation_codes_for_person(person.id, codes, length(codes))
+  end
+
+  def delete_all_confirmation_codes_for_person(person_id, _, n) when n < 1 do
+    get_person(person_id)
+  end
+
+  def delete_all_confirmation_codes_for_person(person_id, codes, n) do
+    [confirmation_code | codes] = codes
+    Repo.delete!(confirmation_code)
+    delete_all_confirmation_codes_for_person(person_id, codes, length(codes))
+  end
+
+  @doc """
+  Update a persons' confirmed attribute to true  `confirmed: true` using a 
+  confirmation code and delete all existing confirmation codes associated with 
+  person.
+
+  ## Example
+
+      iex> confirm_person(confirmation_code)
+      {:ok, %Person
+  """
+
+  def confirm_person(confirmation_code) do
+    SubmissionManager.get_person(confirmation_code.person_id)
+    |> Repo.preload(:confirmation_codes)
+    |> delete_all_confirmation_codes_for_person
+    |> update_person(%{confirmed: true})
+  end
+
+  def person_changeset(%Person{} = person, params \\ %{}) do
     person
-    |> cast(attrs, person_permitted_attributes())
+    |> cast(params, person_permitted_attributes())
     |> validate_required([:name, :email])
+    |> unique_constraint(:email)
+    |> validate_format(:email, email_format_regex())
+  end
+
+  def confirmation_changeset(%ConfirmationCode{} = confirmation, params \\ %{}) do
+    confirmation
+    |> cast(params, [:email, :body, :person_id])
+    |> put_assoc(:person, required: true)
+    |> validate_required([:body])
+  end
+
+  def last_created_confirmation_code(person) do
+    case length(person.confirmation_codes) do
+      0 -> create_person_confirmation(person)
+      _ -> List.last(person.confirmation_codes)
+    end
+    List.last(person.confirmation_codes)
   end
 
   defp person_permitted_attributes do
     [:name, :email, :workshop_idea, :time_needed, :company, :contribution, 
     :donation, :swag, :prizes, :confirmed]
+  end
+
+  defp email_format_regex do
+    ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/
   end
 end

--- a/lib/learnathon/web/controllers/fallback_controller.ex
+++ b/lib/learnathon/web/controllers/fallback_controller.ex
@@ -1,0 +1,28 @@
+defmodule Learnathon.Web.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use Learnathon.Web, :controller
+
+  def call(conn, {:errors, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_flash(:errors, changeset.errors)
+    |> redirect(to: page_path(conn, :index))
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> render(Learnathon.Web.ErrorView, :"404")
+  end
+
+  def call(conn, {:error, message}) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: page_path(conn, :index))
+  end
+
+end
+

--- a/lib/learnathon/web/email.ex
+++ b/lib/learnathon/web/email.ex
@@ -15,12 +15,12 @@ defmodule Learnathon.Email do
     |> text_body(welcome_plain())
   end
 
-  def confirmation_email(person, conn) do
+  def confirmation_email(person, confirmation, conn) do
     base_email()
     |> to(person.email)
     |> subject("Please confirm your email address for learnathon.nyc!")
     |> put_header("Reply-To", "submissions@learnathon.nyc")
-    |> html_body(confirmation_html(person, conn))
+    |> html_body(confirmation_html(confirmation, conn))
     |> text_body(confirmation_plain())
   end
 
@@ -48,14 +48,13 @@ defmodule Learnathon.Email do
     present_email_template("welcome_plain")
   end
 
-  defp confirmation_html(person, conn) do
-    confirmation_code = Person.last_created_confirmation_code(person)
+  defp confirmation_html(confirmation, conn) do
     Phoenix.View.
       render_to_string(
         Learnathon.EmailView, 
         "confirmation.html",
         conn: conn,
-        cc: confirmation_code.body)
+        cc: confirmation.body)
   end
 
   defp confirmation_plain do

--- a/test/submission_manager_test.exs
+++ b/test/submission_manager_test.exs
@@ -19,6 +19,21 @@ defmodule Learnathon.SubmissionManagerTest do
     assert SubmissionManager.get_person!(person.id) == person
   end
 
+  test "get_person! Raises `NoResultsError` if the Person does not exist" do
+    assert_raise Ecto.NoResultsError, fn ->
+      SubmissionManager.get_person!(100)
+    end
+  end
+
+  test "get_person returns the person with given id" do
+    person = insert(:person_no_code)
+    assert SubmissionManager.get_person(person.id) == person
+  end
+
+  test "get_person returns nil if the Person does not exist" do
+    assert SubmissionManager.get_person(100) == nil
+  end
+
   test "create_person/1 with valid data creates a person." do
     assert {:ok, %Person{}} = SubmissionManager.create_person(@create_attrs)
   end
@@ -26,6 +41,46 @@ defmodule Learnathon.SubmissionManagerTest do
   test "create_person/1 with invalid data returns error changeset." do
     assert {:error, %Ecto.Changeset{}} = 
       SubmissionManager.create_person(@invalid_attrs)
+  end
+
+  test "get_or_create_person/1 with valid data returns a person if they exist." do
+    person = insert(:person)
+    changeset = SubmissionManager.
+                person_changeset(%Person{}, %{name: person.name, email: person.email})
+    {:ok, found_person} = SubmissionManager.get_or_create_person(changeset.changes)
+
+    assert person.name == found_person.name
+  end
+
+  test "get_or_create_person/1 with valid data returns a person if they do not exist." do
+    changeset = SubmissionManager.
+                person_changeset(%Person{}, %{name: "tom", email: "tom@fun.com"})
+    {:ok, person} = SubmissionManager.get_or_create_person(changeset.changes)
+
+    assert "tom" == person.name
+  end
+
+  test "create_confirmation/1 
+          with a person struct will create an associated confirmation code" do
+
+    person = build(:person_no_code)
+    SubmissionManager.create_person_confirmation(person)
+  end
+
+  test "delete_all_confirmation_codes_for_person/1 
+          deletes all confirmation codes associated with person." do
+    person = insert(:person)
+             |> SubmissionManager.delete_all_confirmation_codes_for_person
+             |> Repo.preload(:confirmation_codes)
+    assert length(person.confirmation_codes) == 0
+  end
+
+  test "generate_hash/0 will generate a 64 byte string hash" do
+    hash = SubmissionManager.generate_hash()
+    assert String.length(hash) == 64
+  end
+
+  test "get_confirmation_code" do
   end
 
   test "update_person/2 with valid data updates the person." do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,6 +1,9 @@
 defmodule Learnathon.Factory do
   use ExMachina.Ecto, repo: Learnathon.Repo
-  alias Learnathon.{SubmissionManager.Person, SubmissionManager.ConfirmationCode}
+  alias Learnathon.{
+                     SubmissionManager,
+                     SubmissionManager.Person,
+                     SubmissionManager.ConfirmationCode }
 
   def person_factory do
     %Person{
@@ -19,14 +22,14 @@ defmodule Learnathon.Factory do
 
   def confirmation_code_factory do
     %ConfirmationCode{
-      body: ConfirmationCode.generate,
+      body: SubmissionManager.generate_hash(),
       inserted_at: time_now(),
     }
   end
 
   def expired_confirmation_code_factory do
     %ConfirmationCode{
-      body: ConfirmationCode.generate,
+      body: SubmissionManager.generate_hash(),
       inserted_at: sixteen_minutes_from_now(),
     }
   end

--- a/test/web/confirmation_test.exs
+++ b/test/web/confirmation_test.exs
@@ -1,7 +1,7 @@
 defmodule Learnathon.Confirmation do
   import Learnathon.Factory
 
-  alias Learnathon.{Email, SubmissionManager.Person}
+  alias Learnathon.{SubmissionManager, Email}
 
   use ExUnit.Case
   use Learnathon.Web.ConnCase
@@ -9,18 +9,19 @@ defmodule Learnathon.Confirmation do
 
   test "Confirmation email", %{conn: conn} do
     person = build(:person)
-    email = Email.confirmation_email(person, conn)
+    cc = SubmissionManager.last_created_confirmation_code(person)
+    email = Email.confirmation_email(person, cc, conn)
 
     assert email.to == person.email
     assert email.html_body =~ "Please confirm your email"
 
-    confirmation_code = Person.last_created_confirmation_code(person)
+    confirmation_code = SubmissionManager.last_created_confirmation_code(person)
     assert email.html_body =~ confirmation_code.body
   end
 
   test "After confirmation the person gets a thank you email.", %{conn: conn} do
     person = insert(:person)
-    cc = Person.last_created_confirmation_code(person)
+    cc = SubmissionManager.last_created_confirmation_code(person)
     put(conn, submission_path(conn, :update), confirmation_code: cc.body)
 
     assert_delivered_email Learnathon.Email.confirmation_success(person)

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -1,12 +1,34 @@
 defmodule Learnathon.Web.SubmissionControllerTest do
   use Learnathon.Web.ConnCase
 
-  alias Learnathon.SubmissionManager.Person
+  alias Learnathon.{Repo, 
+                    SubmissionManager,
+                    SubmissionManager.Person,}
+
   import Learnathon.Factory
+
+  test "create action will either get or create a person", %{conn: conn} do
+    submission = %{name: "sally", email: "yoyo@gmail.com"}
+    conn = post(conn, submission_path(conn, :create), submission: submission)
+    [person | _] = Repo.all Person
+
+    assert person.name == "sally"
+    assert redirected_to(conn) == page_path(conn, :index)
+  end
+
+  test "create action will create a confirmation code", %{conn: conn} do
+    submission = %{name: "sally", email: "yoyo@gmail.com"}
+    conn = post(conn, submission_path(conn, :create), submission: submission)
+    [person | _] = Repo.all Person
+
+    person = Repo.preload(person, :confirmation_codes)
+    assert length(person.confirmation_codes) == 1
+    assert redirected_to(conn) == page_path(conn, :index)
+  end
 
   test "updates person and redirects", %{conn: conn} do
     person = insert(:person)
-    confirmation_code = Person.last_created_confirmation_code(person)
+    confirmation_code = SubmissionManager.last_created_confirmation_code(person)
 
     conn = put(conn, submission_path(conn, :update), 
                confirmation_code: confirmation_code.body)

--- a/test/web/email_test.exs
+++ b/test/web/email_test.exs
@@ -2,7 +2,11 @@ defmodule Learnathon.EmailTest do
   use ExUnit.Case
   use Learnathon.Web.ConnCase
   use Bamboo.Test, shared: true
-  alias Learnathon.{Email, Mailer}
+  alias Learnathon.{
+                     SubmissionManager,
+                     Email, 
+                     Mailer }
+
   import Learnathon.Factory
 
   test "welcome email" do
@@ -17,10 +21,8 @@ defmodule Learnathon.EmailTest do
 
   test "confirmation email", %{conn: conn} do
     person = build(:person)
-
-    email = Email.confirmation_email(person, conn)
-    cc = Learnathon.
-          SubmissionManager.Person.last_created_confirmation_code(person)
+    cc = SubmissionManager.last_created_confirmation_code(person)
+    email = Email.confirmation_email(person, cc, conn)
 
     assert email.to == person.email
     assert email.
@@ -40,8 +42,9 @@ defmodule Learnathon.EmailTest do
 
   test "after registering, the person gets a confirmation email", %{conn: conn} do
     person = build(:person)
-    Email.confirmation_email(person, conn) |> Mailer.deliver_later
+    cc = SubmissionManager.last_created_confirmation_code(person)
+    Email.confirmation_email(person, cc, conn) |> Mailer.deliver_later
 
-    assert_delivered_email Email.confirmation_email(person, conn)
+    assert_delivered_email Email.confirmation_email(person, cc, conn)
   end
 end

--- a/test/web/models/confirmation_code_test.exs
+++ b/test/web/models/confirmation_code_test.exs
@@ -2,9 +2,11 @@ defmodule Learnathon.ConfirmationCodeTest do
   use Learnathon.ModelCase
   import Learnathon.Factory
 
-  alias Learnathon.SubmissionManager.ConfirmationCode
+  alias Learnathon.{
+                     SubmissionManager,
+                     SubmissionManager.ConfirmationCode, }
 
-  @valid_attrs %{body: ConfirmationCode.generate}
+  @valid_attrs %{body: SubmissionManager.generate_hash}
 
   test "changeset with valid attributes" do
     changeset = ConfirmationCode.changeset(%ConfirmationCode{}, @valid_attrs)

--- a/test/web/person_test.exs
+++ b/test/web/person_test.exs
@@ -2,18 +2,21 @@ defmodule Learnathon.PersonTest do
   import Learnathon.Factory
   use Learnathon.ModelCase
 
-  alias Learnathon.SubmissionManager.Person
+  alias Learnathon.{
+                     SubmissionManager,
+                     SubmissionManager.Person
+                   }
   
   @valid_attrs %{name: "foo", email: "cheese@gmail.com"}
   @invalid_attrs %{name: "foo", email: "chee"}
 
   test "changeset with valid attributes" do
-    changeset = Person.changeset(%Person{}, @valid_attrs)
+    changeset = SubmissionManager.person_changeset(%Person{}, @valid_attrs)
     assert changeset.valid?
   end
 
   test "changeset with invalid attributes" do
-    changeset = Person.changeset(%Person{}, @invalid_attrs)
+    changeset = SubmissionManager.person_changeset(%Person{}, @invalid_attrs)
     refute changeset.valid?
   end
 


### PR DESCRIPTION
- Abstract behaviors from confirmation_code and person data structs. It's
  cleaner to use structs as a template for your data not as a
  namespace for behavior.
- Move all abstracted behavior from data structs to SubmissionManager to
  keep structs skinny. All CRUD behavior goes here.
- Cleanup case statement in submission_controller to with blocks in order
  to make use of a fallback controller. If a conn is not returned the
  fallback controller will handle the last returned value. This will
  usually be a tuple with an error and message.
- Add fallback controller to handle the last returned value of a
  controller
- Update email.ex to match our new conventions.